### PR TITLE
Provide additional information on error

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,8 +22,18 @@ var (
 func main() {
 	app.HelpFlag.Short('h')
 	kingpin.MustParse(app.Parse(os.Args[1:]))
-	if (*asDemon && *asSelector) || (!*asDemon && !*asSelector) {
-		log.Fatal("Missing or incompatible options. See -h/--help for info")
+	modeCount := 0
+	if *asDemon {
+		modeCount++
+	}
+	if *asSelector {
+		modeCount++
+	}
+	if modeCount != 1 {
+		log.Print("Missing or incompatible options. You must provide exactly one of these:")
+		log.Print("  -d, --demon")
+		log.Print("  -s, --select")
+		log.Fatal("See -h/--help for info")
 	}
 
 	h, err := os.UserHomeDir()


### PR DESCRIPTION
When the user doesn't provide exactly one of `--demon` or `--select` we can't do anything, so let's tell the user exactly that.

As a bonus, it makes it trivial to add another mutually-exclusive option (which I'm working on right now: `--clear`, to clear the history)