### PR TITLE
Add filter option to clear command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To query the history and select items, run the binary as `clipman pick -t wofi`.
 You can pass additional arguments to the selector like this: `clipman pick --tool wofi -T'--prompt=my-prompt -i'` (both `--prompt` and `-i` are flags of wofi).
 You can use a custom selector like this: `clipman pick --print0 --tool=CUSTOM --tool-args="fzf --prompt 'pick > ' --bind 'tab:up' --cycle --read0"`.
 
-To remove items from history, `clipman clear -t wofi` and `clipman clear --all`.
+To remove items from history, `clipman clear -t wofi`, `clipman clear --all`, and `clipman clear --filter "text"`.
 
 To serve the last history item at startup, add `exec clipman restore` to your Sway config.
 

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ var (
 	clearToolArgs = clearer.Flag("tool-args", "Extra arguments to pass to the --tool").Short('T').Default("").String()
 	clearAll      = clearer.Flag("all", "Remove all items").Short('a').Default("false").Bool()
 	clearEsc      = clearer.Flag("print0", "Separate items using NULL; recommended if your tool supports --read0 or similar").Default("false").Bool()
+	clearFilter   = clearer.Flag("filter", "Removes all items that match this value").Short('f').String()
 
 	_ = app.Command("restore", "Serve the last recorded item from history")
 )
@@ -99,8 +100,15 @@ func main() {
 			return
 		}
 
+		if *clearFilter != "" {
+			if err := write(filter(history, *clearFilter), histfile); err != nil {
+				smartLog(err.Error(), "normal", *alert)
+			}
+			return;
+		}
+
 		if *clearTool == "" {
-			fmt.Println("clipman: error: required flag --tool or --all not provided, try --help")
+			fmt.Println("clipman: error: required flag --tool, --filter, or --all not provided, try --help")
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
Hi,

I was hoping to add a filter option (`--filter`, `-f`) to the `clear` command that would allow a user to specifically pass an item to remove from clipboard history. This piggy backs off of the tool option, just that it allows a user to explicitly pass an item to be removed from history instead of requiring it to be selected via a tool.

It'd be used like this:
```clipman clear --filter "something"```

The use case I have for this (previously used `clipster` on x11) is that I've got a home grown password manager that puts a selected account's password into the clipboard and after a configured period of time (15 seconds) it prunes that password from the clipboard history. With this additional filter option my password script will be able to perform that prune by passing the password directly as a filter option.