### PR TITLE
option for serve text to the primary clipboard

### DIFF
--- a/docs/clipman.1
+++ b/docs/clipman.1
@@ -15,6 +15,9 @@ Show context-sensitive help (also try --help-long and --help-man).
 \fB--histpath="~/.local/share/clipman.json"\fR
 Path of history file
 .TP
+\fB--primary\fR
+Serve item to the primary clipboard. Default: --no-primary
+.TP
 \fB--notify\fR
 Send desktop notifications on errors
 .TP

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ var (
 	app      = kingpin.New("clipman", "A clipboard manager for Wayland")
 	histpath = app.Flag("histpath", "Path of history file").Default("~/.local/share/clipman.json").String()
 	alert    = app.Flag("notify", "Send desktop notifications on errors").Bool()
+	primary  = app.Flag("primary", "serveTxt to primary clipboard").Default("false").Bool()
 
 	storer    = app.Command("store", "Record clipboard events (run as argument to `wl-paste --watch`)")
 	maxDemon  = storer.Flag("max-items", "history size").Default("15").Int()
@@ -200,6 +201,12 @@ func serveTxt(s string) {
 	cmd := exec.Cmd{Path: bin, Args: []string{bin, "-t", "TEXT"}, Stdin: strings.NewReader(s), SysProcAttr: attr}
 	if err := cmd.Run(); err != nil {
 		smartLog(fmt.Sprintf("error running wl-copy: %s\n", err), "low", *alert)
+	}
+	if *primary {
+		cmd := exec.Cmd{Path: bin, Args: []string{bin, "-p", "-t", "TEXT"}, Stdin: strings.NewReader(s), SysProcAttr: attr}
+		if err := cmd.Run(); err != nil {
+			smartLog(fmt.Sprintf("error running wl-copy -p: %s\n", err), "low", *alert)
+		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -198,16 +198,15 @@ func serveTxt(s string) {
 	}
 
 	// we mandate the mime type because we know we can only serve text; not doing this leads to weird bugs like #35
-	if !*primary {
-		cmd := exec.Cmd{Path: bin, Args: []string{bin, "-t", "TEXT"}, Stdin: strings.NewReader(s), SysProcAttr: attr}
-		if err := cmd.Run(); err != nil {
-			smartLog(fmt.Sprintf("error running wl-copy: %s\n", err), "low", *alert)
-		}
-	}
 	if *primary {
 		cmd := exec.Cmd{Path: bin, Args: []string{bin, "-p", "-t", "TEXT"}, Stdin: strings.NewReader(s), SysProcAttr: attr}
 		if err := cmd.Run(); err != nil {
 			smartLog(fmt.Sprintf("error running wl-copy -p: %s\n", err), "low", *alert)
+		}
+	} else {
+		cmd := exec.Cmd{Path: bin, Args: []string{bin, "-t", "TEXT"}, Stdin: strings.NewReader(s), SysProcAttr: attr}
+		if err := cmd.Run(); err != nil {
+			smartLog(fmt.Sprintf("error running wl-copy: %s\n", err), "low", *alert)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ var (
 	app      = kingpin.New("clipman", "A clipboard manager for Wayland")
 	histpath = app.Flag("histpath", "Path of history file").Default("~/.local/share/clipman.json").String()
 	alert    = app.Flag("notify", "Send desktop notifications on errors").Bool()
-	primary  = app.Flag("primary", "serveTxt to primary clipboard").Default("false").Bool()
+	primary  = app.Flag("primary", "Serve item to the primary clipboard").Default("false").Bool()
 
 	storer    = app.Command("store", "Record clipboard events (run as argument to `wl-paste --watch`)")
 	maxDemon  = storer.Flag("max-items", "history size").Default("15").Int()
@@ -198,9 +198,11 @@ func serveTxt(s string) {
 	}
 
 	// we mandate the mime type because we know we can only serve text; not doing this leads to weird bugs like #35
-	cmd := exec.Cmd{Path: bin, Args: []string{bin, "-t", "TEXT"}, Stdin: strings.NewReader(s), SysProcAttr: attr}
-	if err := cmd.Run(); err != nil {
-		smartLog(fmt.Sprintf("error running wl-copy: %s\n", err), "low", *alert)
+	if !*primary {
+		cmd := exec.Cmd{Path: bin, Args: []string{bin, "-t", "TEXT"}, Stdin: strings.NewReader(s), SysProcAttr: attr}
+		if err := cmd.Run(); err != nil {
+			smartLog(fmt.Sprintf("error running wl-copy: %s\n", err), "low", *alert)
+		}
 	}
 	if *primary {
 		cmd := exec.Cmd{Path: bin, Args: []string{bin, "-p", "-t", "TEXT"}, Stdin: strings.NewReader(s), SysProcAttr: attr}


### PR DESCRIPTION
I added an option to copy clipboard text to the primary. 
this is useful for people that like to use Shift+Insert or Middle click for pasting.

sway config:
```
exec wl-paste -t text --watch clipman --primary store
exec wl-paste -p -t text --watch clipman store -P
bindsym F10 exec clipman --primary pick --tool="wofi" 
```
do you have any concern why it should not be added?